### PR TITLE
[feat]: 회원가입 로그인 페이지 ui 구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,6 +6,7 @@
   --primary: #6F00B6;
   --line: #EDEDED;
   --zighangtext-60: #646464;
+  --label-neutral: #6B7280;
 }
 
 @theme inline {
@@ -14,6 +15,7 @@
   --color-primary: var(--primary);
   --color-line: var(--line);
   --color-zighangtext-60: var(--zighangtext-60);
+  --color-label-neutral: var(--label-neutral);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/app/join/components/HeroSection.tsx
+++ b/src/app/join/components/HeroSection.tsx
@@ -1,0 +1,18 @@
+export default function HeroSection() {
+  return (
+    <div className="flex flex-col items-center gap-5">
+      <div className="flex flex-col items-center text-[28px] font-semibold">
+        <div className="text-center">
+          <span className="text-[#7A52FF]">내 직군의 채용 공고</span>를<br className="md:hidden" />
+          <span className="md:inline hidden"> </span>매일 받아보세요
+        </div>
+      </div>
+      <div className="flex flex-col items-center text-base text-label-neutral">
+        <div className="text-center">
+          오늘 올라온 채용공고 10개를<br className="md:hidden" />
+          <span className="md:inline hidden"> </span>매일 아침 이메일로 보내드립니다
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/join/components/LoginButton.tsx
+++ b/src/app/join/components/LoginButton.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+interface LoginButtonProps {
+  provider: 'kakao' | 'naver' | 'google';
+  onClick?: () => void;
+}
+
+export default function LoginButton({ provider, onClick }: LoginButtonProps) {
+  const providerConfig = {
+    kakao: {
+      name: '카카오 계정으로 계속하기',
+      logo: 'https://zighang.com/mail/kakao.png',
+      alt: 'kakao logo',
+      className: 'rounded-[4px]'
+    },
+    naver: {
+      name: '네이버 계정으로 계속하기',
+      logo: 'https://zighang.com/naver.png',
+      alt: 'naver logo',
+      className: 'rounded-[4px]'
+    },
+    google: {
+      name: '구글 계정으로 계속하기',
+      logo: 'https://zighang.com/google.png',
+      alt: 'google logo',
+      className: 'rounded-[4px] border border-[#EDEDED] p-0.5'
+    }
+  };
+
+  const config = providerConfig[provider];
+
+  return (
+    <div 
+      className="flex h-14 w-full cursor-pointer flex-row items-center justify-center rounded-lg border border-[#D5D7DA] bg-white hover:bg-zinc-100/60 active:bg-zinc-100"
+      onClick={onClick}
+    >
+      <div className="mr-4 h-7 w-7">
+        <img
+          alt={config.alt}
+          loading="lazy"
+          width="28"
+          height="28"
+          decoding="async"
+          className={config.className}
+          src={config.logo}
+        />
+      </div>
+      <div className="text-start text-base font-medium text-[#414651]">
+        {config.name}
+      </div>
+    </div>
+  );
+}

--- a/src/app/join/components/LoginButtons.tsx
+++ b/src/app/join/components/LoginButtons.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import LoginButton from "./LoginButton";
+
+export default function LoginButtons() {
+  const handleKakaoLogin = () => {
+    console.log("카카오 로그인");
+  };
+
+  const handleNaverLogin = () => {
+    console.log("네이버 로그인");
+  };
+
+  const handleGoogleLogin = () => {
+    console.log("구글 로그인");
+  };
+
+  return (
+    <div className="flex w-full flex-col items-center gap-2 px-7 md:gap-3 md:px-24">
+      <LoginButton provider="kakao" onClick={handleKakaoLogin} />
+      <LoginButton provider="naver" onClick={handleNaverLogin} />
+      <LoginButton provider="google" onClick={handleGoogleLogin} />
+    </div>
+  );
+}

--- a/src/app/join/components/PrivacyLinks.tsx
+++ b/src/app/join/components/PrivacyLinks.tsx
@@ -1,0 +1,23 @@
+export default function PrivacyLinks() {
+  return (
+    <div className="flex w-full flex-row items-center justify-center text-xs text-[#363636]">
+      <a
+        className="hover:underline"
+        href="https://quasar-guava-e9f.notion.site/1f5144e6653280379023dacb5593b2dd?pvs=74"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        개인정보 처리 방침
+      </a>
+      <div className="mx-2">|</div>
+      <a
+        className="hover:underline"
+        href="https://quasar-guava-e9f.notion.site/1f5144e6653280fe9217f4a46a343de0"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        이용 약관
+      </a>
+    </div>
+  );
+}

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -1,0 +1,17 @@
+import HeroSection from './components/HeroSection';
+import LoginButtons from './components/LoginButtons';
+import PrivacyLinks from './components/PrivacyLinks';
+
+export default function JoinPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center">
+      <div className="relative w-full md:px-10 md:max-w-screen-lg overflow-visible md:mx-auto">
+        <section className="flex h-screen w-full flex-col items-center justify-center gap-10 md:gap-[50px]">
+          <HeroSection />
+          <LoginButtons />
+          <PrivacyLinks />
+        </section>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

>  #6 

## 📝작업 내용

> 로그인 회원가입 페이지(/join) 구현

### 스크린샷 (선택)

<img width="950" height="931" alt="image" src="https://github.com/user-attachments/assets/9fee38d3-5c1c-4fe0-9a9e-4d8a48d291c1" />
<img width="497" height="929" alt="image" src="https://github.com/user-attachments/assets/a5f99c51-d079-44d7-a311-e859221d4492" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?