### PR TITLE
[Test]: filterTag 테스트 코드

### DIFF
--- a/__tests__/FilterTag.test.tsx
+++ b/__tests__/FilterTag.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import FilterTagSelect, { type Option } from "@/app/components/FilterTag";
+
+// 실제 popover 까지 연동하려니 popover 에도 로직이 있어서 가짜 컴포넌트로 대체
+jest.mock("@/app/components/PopOver", () => ({
+  PopoverPanel: (props: any) =>
+    props.open ? (
+      <div data-testid="popover-panel" aria-label={props.label}>
+        <button data-testid="a 선택" onClick={() => props.onChange(["a"])}>
+          a 선택
+        </button>
+      </div>
+    ) : null,
+}));
+
+// 사용할 옵션 더미 데이터
+const OPTIONS: Option[] = [
+  { id: "ALL", label: "전체" },
+  { id: "a", label: "A-라벨" },
+  { id: "b", label: "B-라벨" },
+];
+
+// 렌더되는 첫 번째 버튼을 가져오기
+function getTrigger() {
+  return screen.getAllByRole("button")[0];
+}
+
+describe("FilterTagSelect - 열림과 버튼 텍스트 변환", () => {
+  test("버튼 클릭 시 패널이 열림", () => {
+    render(<FilterTagSelect label="산업" options={OPTIONS} />);
+
+    const trigger = getTrigger();
+    expect(trigger).toHaveAttribute("aria-expanded", "false"); // 초기 닫힘 상태
+    expect(screen.queryByTestId("popover-panel")).toBeNull(); // 버튼 클리했을 때 뜨는 popover 패널이 없는 상태
+
+    fireEvent.click(trigger); // 열림 버튼 누르기
+
+    expect(trigger).toHaveAttribute("aria-expanded", "true"); //열림 상태
+    expect(screen.getByTestId("popover-panel")).toBeInTheDocument(); // popover 패널이 있는 상태
+  });
+
+  test("옵션 선택 시 버튼 텍스트가 해당 라벨로 변환", () => {
+    render(<FilterTagSelect label="산업" options={OPTIONS} />);
+
+    fireEvent.click(getTrigger()); //패널 열기
+    fireEvent.click(screen.getByTestId("a 선택")); // a선택하기
+    expect(screen.getByText("A-라벨")).toBeInTheDocument(); // 버튼이 a라벨로 변경
+  });
+});


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #28 

## 📝작업 내용

> 필터 태그에서 열림 닫힘이 제대로 되는지, 그리고 열고 popover에서 라벨들을 선택했을 때 제대로 선택되어 버튼이 변화하는지 테스트 했습니다

### 스크린샷 (선택)
 <img width="318" height="265" alt="image" src="https://github.com/user-attachments/assets/48020a40-6fda-4063-afc6-16ce2bbe3659" />

pass 되었습니다
## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 기업 목록/상세 페이지 추가 및 필터 바/필터 다이얼로그 도입으로 다중 조건 필터링 지원
  - 팝오버/모달 기반 필터 선택 컴포넌트 제공, 옵션 세트(산업/지역/기업규모/형태/학력/경력/마감) 추가
- 스타일
  - 기업 카드 레이아웃과 타이포그래피 개선, 채용 카드 목록을 반응형 그리드로 전환
- 테스트
  - 필터 태그 동작 및 기본 유닛 테스트 추가
- 리팩터
  - 기존 인터랙티브 필터 컴포넌트 제거 및 구조 개편
- 잡무
  - 사전 배포 워크플로우, 커밋 메시지 검증/프리커밋 린트, 테스트 설정 및 스크립트 구성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->