### PR TITLE
[feat]: 자소서 api 연동

### DIFF
--- a/src/app/(pages)/onboarding/_components/RecommendCard/RecruitmentCardList.tsx
+++ b/src/app/(pages)/onboarding/_components/RecommendCard/RecruitmentCardList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Swiper, SwiperSlide } from "swiper/react";
-import { Autoplay, Navigation, Pagination, FreeMode } from "swiper/modules";
+import { Autoplay, FreeMode } from "swiper/modules";
 import "swiper/css";
 import "swiper/css/navigation";
 import "swiper/css/pagination";

--- a/src/app/(pages)/onboarding/_funnel/steps/EducationStep.tsx
+++ b/src/app/(pages)/onboarding/_funnel/steps/EducationStep.tsx
@@ -60,15 +60,12 @@ export function EducationStep({
         onBack={onBack}
       />
 
-      <p
-        role="heading"
-        className="text-Heading2-20sb md:hidden items-center justify-center gap-[6px] text-black p-7 pb-0 "
-      >
+      <div className="text-Heading2-20sb md:hidden items-center justify-center gap-[6px] text-black p-7 pb-0 ">
         <span className="flex">
           <p className="text-violet-500">최종학력</p>이
         </span>
         어떻게 되세요?
-      </p>
+      </div>
 
       <div className="w-full flex flex-col items-center md:h-[calc(500px-55px)]">
         <div className="mt-[58px] flex items-start gap-[16px]">

--- a/src/app/(pages)/onboarding/_funnel/steps/ExperienceStep.tsx
+++ b/src/app/(pages)/onboarding/_funnel/steps/ExperienceStep.tsx
@@ -198,7 +198,7 @@ export function ExperienceStep({
         totalSteps={4}
         onBack={onBack}
       />
-      <h1 className="text-Heading2-20sb md:hidden flex flex-col text-black p-7 pb-0">
+      <div className="text-Heading2-20sb md:hidden flex flex-col text-black p-7 pb-0">
         가고 싶은 직군의 <br />
         <span className="flex">
           <p className="text-violet-500">경력</p>이 어떻게 되세요?
@@ -214,7 +214,7 @@ export function ExperienceStep({
             <InfoCircle />
           </InfoTooltip>
         </span>
-      </h1>
+      </div>
       <div
         className="w-full flex flex-col items-center md:h-[calc(500px-55px)] select-none"
         onTouchStart={onTouchStartPage}

--- a/src/app/(pages)/onboarding/_funnel/steps/ExploreJobStep.tsx
+++ b/src/app/(pages)/onboarding/_funnel/steps/ExploreJobStep.tsx
@@ -55,12 +55,12 @@ export function ExploreJobStep({
       />
 
       {!showPreview && (
-        <h1 className="text-Heading2-20sb md:hidden items-center justify-center gap-[6px] text-black p-7 pb-0">
+        <div className="text-Heading2-20sb md:hidden items-center justify-center gap-[6px] text-black p-7 pb-0">
           <span className="flex">
             <p className="text-violet-500">성향에 맞는 카드</p>를
           </span>
           선택해주세요
-        </h1>
+        </div>
       )}
 
       <div className="h-full flex flex-col items-center mt-20">

--- a/src/app/(pages)/onboarding/_funnel/steps/JobCategoryStep.tsx
+++ b/src/app/(pages)/onboarding/_funnel/steps/JobCategoryStep.tsx
@@ -47,14 +47,14 @@ export function JobCategoryStep({
         totalSteps={4}
       />
 
-      <p className="text-Heading2-20sb md:hidden items-center justify-center gap-[6px] text-black p-7 pb-0">
+      <div className="text-Heading2-20sb md:hidden items-center justify-center gap-[6px] text-black p-7 pb-0">
         <span className="flex">
           원하는 <p className="text-violet-500">직군</p>을 선택해주세요.
         </span>
         <span className="text-Subheading3-14m text-[#767678] inline-flex items-center gap-1">
           (최대 3개 선택)
         </span>
-      </p>
+      </div>
 
       <div className="w-full px-6 md:w-[613px] md:px-0 mt-5.5 md:mt-[80px] mx-auto pb-20 md:pb-0 grid grid-cols-3 md:flex md:flex-wrap gap-2 mb-[110px] md:[&>*:nth-child(1)]:ml-3 md:[&>*:nth-child(20)]:ml-3">
         {onboardingJobCategories.map((category) => (

--- a/src/app/(pages)/onboarding/_funnel/steps/LocationStep.tsx
+++ b/src/app/(pages)/onboarding/_funnel/steps/LocationStep.tsx
@@ -57,13 +57,13 @@ export function LocationStep({
         onBack={onBack}
       />
 
-      <p className="text-Heading2-20sb md:hidden items-center justify-center gap-[6px] text-black p-7 pb-0">
+      <div className="text-Heading2-20sb md:hidden items-center justify-center gap-[6px] text-black p-7 pb-0">
         <span className="flex">
           원하는
           <p className="text-violet-500 ml-[6px]">근무 지역</p>이
         </span>
         어떻게 되세요?
-      </p>
+      </div>
 
       <div className="flex flex-col md:flex-row items-center justify-center mt-6">
         <OnboardingMap

--- a/src/app/(pages)/personal/_components/file/fileList.tsx
+++ b/src/app/(pages)/personal/_components/file/fileList.tsx
@@ -8,14 +8,6 @@ import {
   useDeleteResume,
 } from "@/app/_api/resume/hooks/useResumes";
 
-type FileRow = {
-  id: string;
-  fileName: string;
-  fileUrl: string;
-  size: number;
-  uploadDate: string;
-};
-
 type FileListProps = {
   onFilesChange?: (hasFiles: boolean) => void;
 };
@@ -24,7 +16,7 @@ export default function FileList({ onFilesChange }: FileListProps) {
   const [deletingFileId, setDeletingFileId] = useState<string | null>(null);
 
   // React Query hooks 사용
-  const { data: resumeData, isLoading: loading, error } = useResumes();
+  const { data: resumeData } = useResumes();
   const deleteResumeMutation = useDeleteResume();
 
   const files = resumeData?.resumes || [];

--- a/src/app/(pages)/personal/_components/file/fileList.tsx
+++ b/src/app/(pages)/personal/_components/file/fileList.tsx
@@ -24,6 +24,7 @@ export default function FileList({
 }: FileListProps) {
   const [files, setFiles] = useState<FileRow[]>([]);
   const [loading, setLoading] = useState(true);
+  const [deletingFileId, setDeletingFileId] = useState<string | null>(null);
   const isEmpty = files.length === 0;
 
   // 파일 목록 가져오기
@@ -71,6 +72,7 @@ export default function FileList({
 
   const handleDelete = async (id: string) => {
     try {
+      setDeletingFileId(id);
       await deleteResume(id);
       // 삭제 후 목록에서 제거
       const updatedFiles = files.filter((file) => file.id !== id);
@@ -78,8 +80,12 @@ export default function FileList({
       if (onFilesChange) {
         onFilesChange(updatedFiles.length > 0);
       }
+      alert("삭제 완료!");
     } catch (error) {
       console.error("파일 삭제에 실패했습니다:", error);
+      alert("파일 삭제에 실패했습니다.");
+    } finally {
+      setDeletingFileId(null);
     }
   };
 
@@ -116,6 +122,7 @@ export default function FileList({
                 }}
                 index={idx}
                 onDelete={handleDelete}
+                isDeleting={deletingFileId === file.id}
               />
             ))}
           </ul>

--- a/src/app/(pages)/personal/_components/file/fileRender.tsx
+++ b/src/app/(pages)/personal/_components/file/fileRender.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { useDownloadResume } from "@/app/_api/resume/hooks/useResumes";
+
 interface FileRenderProps {
   file: {
     id: string;
@@ -18,6 +22,7 @@ export default function FileRender({
   onDelete,
   isDeleting = false,
 }: FileRenderProps) {
+  const downloadResumeMutation = useDownloadResume();
   return (
     <div className="grid grid-cols-12 items-center p-3 md:px-7 md:py-2.5 bg-white border-b border-gray-200 hover:bg-gray-50 transition-colors">
       {/* 번호 */}
@@ -31,18 +36,12 @@ export default function FileRender({
       <div className="col-span-7">
         <button
           onClick={() => {
-            if (file.url) {
-              const link = document.createElement("a");
-              link.href = file.url;
-              link.download = file.name;
-              document.body.appendChild(link);
-              link.click();
-              document.body.removeChild(link);
-            }
+            downloadResumeMutation.mutate(file.id);
           }}
-          className="text-sm font-medium text-gray-900 hover:text-blue-600 hover:border-b hover:border-blue-600 transition-colors cursor-pointer text-left inline-block"
+          disabled={downloadResumeMutation.isPending}
+          className="text-sm font-medium text-gray-900 hover:text-blue-600 hover:border-b hover:border-blue-600 transition-colors cursor-pointer text-left inline-block disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {file.name}
+          {downloadResumeMutation.isPending ? "다운로드 중..." : file.name}
         </button>
       </div>
 

--- a/src/app/(pages)/personal/_components/file/fileRender.tsx
+++ b/src/app/(pages)/personal/_components/file/fileRender.tsx
@@ -9,9 +9,15 @@ interface FileRenderProps {
   };
   index: number;
   onDelete: (id: string) => void;
+  isDeleting?: boolean;
 }
 
-export default function FileRender({ file, index, onDelete }: FileRenderProps) {
+export default function FileRender({
+  file,
+  index,
+  onDelete,
+  isDeleting = false,
+}: FileRenderProps) {
   return (
     <div className="grid grid-cols-12 items-center p-3 md:px-7 md:py-2.5 bg-white border-b border-gray-200 hover:bg-gray-50 transition-colors">
       {/* 번호 */}
@@ -49,13 +55,17 @@ export default function FileRender({ file, index, onDelete }: FileRenderProps) {
 
       {/* 삭제 버튼 */}
       <div className="col-span-3 md:col-span-1 text-right ">
-        <button
-          onClick={() => onDelete(file.id)}
-          className="cursor-pointer p-1 text-gray-400 hover:text-red-500 transition-colors"
-          title="파일 삭제"
-        >
-          <DeleteIcon />
-        </button>
+        {isDeleting ? (
+          <div className="p-1 text-gray-500 text-xs">삭제 중...</div>
+        ) : (
+          <button
+            onClick={() => onDelete(file.id)}
+            className="cursor-pointer p-1 text-gray-400 hover:text-red-500 transition-colors"
+            title="파일 삭제"
+          >
+            <DeleteIcon />
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/app/(pages)/personal/_components/file/fileUploadModal.tsx
+++ b/src/app/(pages)/personal/_components/file/fileUploadModal.tsx
@@ -22,6 +22,7 @@ export default function FileUploadModal({
 }: FileUploadModalProps) {
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [fileProgress, setFileProgress] = useState<
     Record<
@@ -92,6 +93,8 @@ export default function FileUploadModal({
       return;
     }
 
+    setIsSubmitting(true);
+
     try {
       // 모든 파일을 순차적으로 실제 업로드
       for (let i = 0; i < originalFiles.length; i++) {
@@ -133,6 +136,8 @@ export default function FileUploadModal({
           ? error.message
           : "파일 업로드 중 오류가 발생했습니다."
       );
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -278,13 +283,13 @@ export default function FileUploadModal({
                 <button
                   onClick={handleComplete}
                   className={`hidden md:block ml-auto text-white text-sm font-semibold h-9 px-7 py-2 rounded-lg ${
-                    uploadedFiles.length > 0
+                    uploadedFiles.length > 0 && !isSubmitting
                       ? "bg-violet-600 hover:bg-violet-700"
                       : "bg-neutral-400 cursor-not-allowed"
                   }`}
-                  disabled={uploadedFiles.length === 0}
+                  disabled={uploadedFiles.length === 0 || isSubmitting}
                 >
-                  완료
+                  {isSubmitting ? "제출 중..." : "완료"}
                 </button>
               </div>
               <div className="flex gap-2 mb-2">
@@ -297,13 +302,13 @@ export default function FileUploadModal({
                 <button
                   onClick={handleComplete}
                   className={`flex-1 md:hidden  text-white text-sm font-semibold h-9 px-7 py-2 rounded-lg ${
-                    uploadedFiles.length > 0
+                    uploadedFiles.length > 0 && !isSubmitting
                       ? "bg-violet-600 hover:bg-violet-700"
                       : "bg-neutral-400 cursor-not-allowed"
                   }`}
-                  disabled={uploadedFiles.length === 0}
+                  disabled={uploadedFiles.length === 0 || isSubmitting}
                 >
-                  완료
+                  {isSubmitting ? "제출 중..." : "완료"}
                 </button>
               </div>
             </div>

--- a/src/app/(pages)/personal/_components/file/fileUploadModal.tsx
+++ b/src/app/(pages)/personal/_components/file/fileUploadModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Dialog } from "@headlessui/react";
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import FileUploadCard from "@/app/(pages)/onboarding/_components/FileUpload/FileUploadCard";
 import { FileUploadItem } from "@/app/(pages)/onboarding/_components/FileUpload/FileUploadItem";
 import CheckIcon from "@/app/(pages)/onboarding/_components/FileUpload/icons/checkIcon";
@@ -31,6 +31,17 @@ export default function FileUploadModal({
     >
   >({});
   const [originalFiles, setOriginalFiles] = useState<File[]>([]);
+
+  // 모달이 열릴 때마다 상태 초기화
+  useEffect(() => {
+    if (open) {
+      setUploadedFiles([]);
+      setError(null);
+      setIsSubmitting(false);
+      setFileProgress({});
+      setOriginalFiles([]);
+    }
+  }, [open]);
 
   const processFileSequentially = async (files: File[]) => {
     setOriginalFiles(files);

--- a/src/app/(pages)/personal/_components/file/fileUploadModal.tsx
+++ b/src/app/(pages)/personal/_components/file/fileUploadModal.tsx
@@ -7,7 +7,7 @@ import { FileUploadItem } from "@/app/(pages)/onboarding/_components/FileUpload/
 import CheckIcon from "@/app/(pages)/onboarding/_components/FileUpload/icons/checkIcon";
 import { UploadIcon } from "../../_Icons/UploadIcon";
 import { UploadedFile } from "@/app/(pages)/onboarding/_components/FileUpload/types/type";
-import { uploadResume } from "@/app/_api/resume/resumeApi";
+import { useUploadResume } from "@/app/_api/resume/hooks/useResumes";
 
 type FileUploadModalProps = {
   open: boolean;
@@ -31,6 +31,7 @@ export default function FileUploadModal({
     >
   >({});
   const [originalFiles, setOriginalFiles] = useState<File[]>([]);
+  const uploadResumeMutation = useUploadResume();
 
   // 모달이 열릴 때마다 상태 초기화
   useEffect(() => {
@@ -116,7 +117,7 @@ export default function FileUploadModal({
 
         try {
           // 실제 API 호출
-          const response = await uploadResume(file);
+          const response = await uploadResumeMutation.mutateAsync(file);
 
           if (response.success) {
             // 업로드 성공 - 상태는 그대로 유지 (이미 success로 표시됨)

--- a/src/app/(pages)/personal/_components/file/stories/fileList.stories.tsx
+++ b/src/app/(pages)/personal/_components/file/stories/fileList.stories.tsx
@@ -9,13 +9,9 @@ const meta: Meta<typeof FileList> = {
   },
   tags: ["autodocs"],
   argTypes: {
-    files: {
-      control: "object",
-      description: "파일 목록 배열",
-    },
-    onDelete: {
-      action: "deleted",
-      description: "파일 삭제 콜백",
+    onFilesChange: {
+      action: "filesChanged",
+      description: "파일 목록 변경 콜백",
     },
   },
 };
@@ -23,71 +19,8 @@ const meta: Meta<typeof FileList> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Empty: Story = {
+export const Default: Story = {
   args: {
-    files: [],
-    onDelete: (id) => console.log("Delete file:", id),
-  },
-};
-
-export const WithFiles: Story = {
-  args: {
-    files: [
-      {
-        id: "1",
-        name: "resume.pdf",
-        type: "application/pdf",
-        size: 1024000,
-        url: "https://example.com/resume.pdf",
-        uploadDate: "2024-01-15",
-      },
-      {
-        id: "2",
-        name: "portfolio.pdf",
-        type: "application/pdf",
-        size: 2048000,
-        url: "https://example.com/portfolio.pdf",
-        uploadDate: "2024-01-16",
-      },
-      {
-        id: "3",
-        name: "cover-letter.pdf",
-        type: "application/pdf",
-        size: 512000,
-        url: "https://example.com/cover-letter.pdf",
-        uploadDate: "2024-01-17",
-      },
-    ],
-    onDelete: (id) => console.log("Delete file:", id),
-  },
-};
-
-export const SingleFile: Story = {
-  args: {
-    files: [
-      {
-        id: "1",
-        name: "document.pdf",
-        type: "application/pdf",
-        size: 1536000,
-        url: "https://example.com/document.pdf",
-        uploadDate: "2024-01-18",
-      },
-    ],
-    onDelete: (id) => console.log("Delete file:", id),
-  },
-};
-
-export const ManyFiles: Story = {
-  args: {
-    files: Array.from({ length: 10 }, (_, i) => ({
-      id: `${i + 1}`,
-      name: `file-${i + 1}.pdf`,
-      type: "application/pdf",
-      size: Math.floor(Math.random() * 5000000) + 100000,
-      url: `https://example.com/file-${i + 1}.pdf`,
-      uploadDate: `2024-01-${String(i + 1).padStart(2, "0")}`,
-    })),
-    onDelete: (id) => console.log("Delete file:", id),
+    onFilesChange: (hasFiles) => console.log("Files changed:", hasFiles),
   },
 };

--- a/src/app/(pages)/personal/_components/personalBanner.tsx
+++ b/src/app/(pages)/personal/_components/personalBanner.tsx
@@ -1,12 +1,12 @@
 import Image from "next/image";
 
 interface PersonalBannerProps {
-  files?: Array<{ id: string; name: string; uploadedAt: string }>;
+  hasFiles: boolean;
 }
 
-export default function PersonalBanner({ files = [] }: PersonalBannerProps) {
+export default function PersonalBanner({ hasFiles }: PersonalBannerProps) {
   // 파일이 하나라도 있으면 배너를 숨김
-  if (files.length > 0) {
+  if (hasFiles) {
     return null;
   }
 

--- a/src/app/(pages)/personal/_components/personalMain.tsx
+++ b/src/app/(pages)/personal/_components/personalMain.tsx
@@ -7,9 +7,14 @@ import UploadArea from "./uploadArea";
 
 export default function PersonalMain() {
   const [hasFiles, setHasFiles] = useState(false);
+  const [isAnalysisModalOpen, setIsAnalysisModalOpen] = useState(false);
 
   const handleFileChange = (hasFiles: boolean) => {
     setHasFiles(hasFiles);
+  };
+
+  const handleAnalysisModalChange = (isOpen: boolean) => {
+    setIsAnalysisModalOpen(isOpen);
   };
 
   return (
@@ -18,8 +23,15 @@ export default function PersonalMain() {
         맞춤공고
       </h2>
       <PersonalBanner hasFiles={hasFiles} />
-      <RecommendArea hasFiles={hasFiles} onFileUpload={() => {}} />
-      <UploadArea onFilesChange={handleFileChange} />
+      <RecommendArea
+        hasFiles={hasFiles}
+        isAnalysisModalOpen={isAnalysisModalOpen}
+        onFileUpload={() => {}}
+      />
+      <UploadArea
+        onFilesChange={handleFileChange}
+        onAnalysisModalChange={handleAnalysisModalChange}
+      />
     </div>
   );
 }

--- a/src/app/(pages)/personal/_components/personalMain.tsx
+++ b/src/app/(pages)/personal/_components/personalMain.tsx
@@ -5,17 +5,11 @@ import PersonalBanner from "./personalBanner";
 import RecommendArea from "./recommendArea";
 import UploadArea from "./uploadArea";
 
-type FileRow = {
-  id: string;
-  name: string;
-  uploadedAt: string;
-};
-
 export default function PersonalMain() {
-  const [files, setFiles] = useState<FileRow[]>([]);
+  const [hasFiles, setHasFiles] = useState(false);
 
-  const handleFileUpload = (newFiles: FileRow[]) => {
-    setFiles(newFiles);
+  const handleFileChange = (hasFiles: boolean) => {
+    setHasFiles(hasFiles);
   };
 
   return (
@@ -23,9 +17,9 @@ export default function PersonalMain() {
       <h2 className="text-black text-xl md:text-2xl font-semibold ">
         맞춤공고
       </h2>
-      <PersonalBanner files={files} />
-      <RecommendArea hasFiles={files.length > 0} onFileUpload={() => {}} />
-      <UploadArea onFilesChange={handleFileUpload} />
+      <PersonalBanner hasFiles={hasFiles} />
+      <RecommendArea hasFiles={hasFiles} onFileUpload={() => {}} />
+      <UploadArea onFilesChange={handleFileChange} />
     </div>
   );
 }

--- a/src/app/(pages)/personal/_components/recommendArea.tsx
+++ b/src/app/(pages)/personal/_components/recommendArea.tsx
@@ -5,7 +5,6 @@ import PersonalizedRecruitmentList from "./recruitment/PersonalizedRecruitmentLi
 import { useState, useEffect } from "react";
 import { fetchRecommendedRecruitments } from "@/app/_api/recruitment/recommend/recommend";
 import type { RecommendedRecruitment } from "@/app/_types/jobs";
-import PersonalizedRecruitmentBanner from "./recruitment/PersonalizedRecruitmentBanner";
 
 // 임시 목업 데이터 (파일이 없을 때 사용)
 const mockRecruitments = [
@@ -141,7 +140,7 @@ export default function RecommendArea({
           건
         </div>
       </div>
-      <PersonalizedRecruitmentBanner userName="민수" />
+
       {hasFiles && !isAnalysisModalOpen ? (
         // 파일이 있고 분석 모달이 열려있지 않을 때
         isLoading ? (

--- a/src/app/(pages)/personal/_components/recommendArea.tsx
+++ b/src/app/(pages)/personal/_components/recommendArea.tsx
@@ -39,7 +39,6 @@ interface RecommendAreaProps {
 export default function RecommendArea({
   hasFiles = false,
   isAnalysisModalOpen = false,
-  onFileUpload,
 }: RecommendAreaProps) {
   const [recruitmentCount, setRecruitmentCount] = useState(0);
 

--- a/src/app/(pages)/personal/_components/recommendArea.tsx
+++ b/src/app/(pages)/personal/_components/recommendArea.tsx
@@ -5,6 +5,7 @@ import PersonalizedRecruitmentList from "./recruitment/PersonalizedRecruitmentLi
 import { useState, useEffect } from "react";
 import { fetchRecommendedRecruitments } from "@/app/_api/recruitment/recommend/recommend";
 import type { RecommendedRecruitment } from "@/app/_types/jobs";
+import PersonalizedRecruitmentBanner from "./recruitment/PersonalizedRecruitmentBanner";
 
 // 임시 목업 데이터 (파일이 없을 때 사용)
 const mockRecruitments = [
@@ -103,7 +104,7 @@ export default function RecommendArea({
   };
 
   return (
-    <div className="mt-5">
+    <div className="mt-5 ">
       <div className="flex justify-between items-center mb-4">
         <div className="justify-center text-black text-lg md:text-xl font-semibold">
           <span className="text-purple-800 text-lg md:text-xl font-semibold mr-1">
@@ -116,7 +117,7 @@ export default function RecommendArea({
           건
         </div>
       </div>
-
+      <PersonalizedRecruitmentBanner userName="민수" />
       {hasFiles && !isAnalysisModalOpen ? (
         // 파일이 있고 분석 모달이 열려있지 않을 때
         isLoading ? (

--- a/src/app/(pages)/personal/_components/recommendArea.tsx
+++ b/src/app/(pages)/personal/_components/recommendArea.tsx
@@ -5,7 +5,6 @@ import PersonalizedRecruitmentList from "./recruitment/PersonalizedRecruitmentLi
 import { useState, useEffect } from "react";
 import { useAllRecommendedRecruitments } from "@/app/_api/recruitment/recommend/useRecommend";
 import type { RecommendedRecruitment } from "@/app/_types/jobs";
-import PersonalizedRecruitmentBanner from "./recruitment/PersonalizedRecruitmentBanner";
 
 // 임시 목업 데이터 (파일이 없을 때 사용)
 const mockRecruitments = [

--- a/src/app/(pages)/personal/_components/recommendArea.tsx
+++ b/src/app/(pages)/personal/_components/recommendArea.tsx
@@ -32,11 +32,13 @@ const mockRecruitments = [
 
 interface RecommendAreaProps {
   hasFiles?: boolean;
+  isAnalysisModalOpen?: boolean;
   onFileUpload?: () => void;
 }
 
 export default function RecommendArea({
   hasFiles = false,
+  isAnalysisModalOpen = false,
   onFileUpload,
 }: RecommendAreaProps) {
   const [recruitmentCount, setRecruitmentCount] = useState(0);
@@ -65,9 +67,17 @@ export default function RecommendArea({
         </div>
       </div>
 
-      {hasFiles ? (
-        // 파일이 있을 때: PersonalizedRecruitmentList 표시
+      {hasFiles && !isAnalysisModalOpen ? (
+        // 파일이 있고 분석 모달이 열려있지 않을 때: PersonalizedRecruitmentList 표시
         <PersonalizedRecruitmentList items={mockRecruitments} />
+      ) : hasFiles && isAnalysisModalOpen ? (
+        // 파일이 있고 분석 모달이 열려있을 때: 로딩 상태 표시
+        <div className="flex items-center justify-center h-64 bg-gray-50 rounded-lg">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-violet-500 mx-auto mb-2"></div>
+            <p className="text-gray-600 text-sm">공고를 분석하고 있습니다...</p>
+          </div>
+        </div>
       ) : (
         // 파일이 없을 때: 기존 업로드 유도 UI 표시
         <div className="relative w-full max-w-[787px] h-72 md:h-43">

--- a/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentBanner.tsx
+++ b/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentBanner.tsx
@@ -2,8 +2,7 @@
 
 import { Profile } from "@/components/Icons/Profile";
 import KeywordButton from "./keywordButton";
-import { useState, useEffect } from "react";
-import { fetchKeywords } from "@/app/_api/resume/keyword/keywordApi";
+import { useKeywords } from "@/app/_api/resume/hooks/useKeywords";
 
 interface PersonalizedRecruitmentBannerProps {
   userName?: string;
@@ -14,25 +13,7 @@ export default function PersonalizedRecruitmentBanner({
   userName = "민수",
   onKeywordClick,
 }: PersonalizedRecruitmentBannerProps) {
-  const [keywords, setKeywords] = useState<string[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const loadKeywords = async () => {
-      try {
-        setLoading(true);
-        const fetchedKeywords = await fetchKeywords();
-        setKeywords(fetchedKeywords);
-      } catch (error) {
-        console.error("키워드를 가져오는데 실패했습니다:", error);
-        setKeywords([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadKeywords();
-  }, []);
+  const { data: keywords = [], isLoading: loading, error } = useKeywords();
 
   return (
     <div className="p-4 flex flex-col items-center justify-center min-w-64 min-h-36 md:w-full md:min-h-18 md:flex-row md:gap-7 bg-violet-50 rounded-lg mb-3.5">

--- a/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentBanner.tsx
+++ b/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentBanner.tsx
@@ -6,12 +6,10 @@ import { useKeywords } from "@/app/_api/resume/hooks/useKeywords";
 
 interface PersonalizedRecruitmentBannerProps {
   userName?: string;
-  onKeywordClick?: (keyword: string) => void;
 }
 
 export default function PersonalizedRecruitmentBanner({
   userName = "민수",
-  onKeywordClick,
 }: PersonalizedRecruitmentBannerProps) {
   const { data: keywords = [], isLoading: loading } = useKeywords();
 
@@ -26,11 +24,7 @@ export default function PersonalizedRecruitmentBanner({
           <p className="text-gray-500 text-sm">키워드를 불러오는 중...</p>
         ) : keywords.length > 0 ? (
           keywords.map((keyword, index) => (
-            <KeywordButton
-              key={`${keyword}-${index}`}
-              keyword={keyword}
-              onClick={() => onKeywordClick?.(keyword)}
-            />
+            <KeywordButton key={`${keyword}-${index}`} keyword={keyword} />
           ))
         ) : (
           <p className="text-gray-500 text-sm">키워드가 없습니다.</p>

--- a/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentBanner.tsx
+++ b/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentBanner.tsx
@@ -14,12 +14,12 @@ export default function PersonalizedRecruitmentBanner({
   const { data: keywords = [], isLoading: loading } = useKeywords();
 
   return (
-    <div className="px-2 py-4 md:p-4 flex flex-col items-center justify-center min-w-64 min-h-36 md:w-full md:min-h-18 md:flex-row md:gap-7 bg-violet-50 rounded-lg mb-3.5">
+    <div className="px-1 py-4 md:p-4 flex flex-col items-center justify-center w-60 min-h-36 md:w-full md:min-h-18 md:flex-row md:gap-7 bg-violet-50 rounded-lg mb-3.5">
       <div className="flex items-center gap-2">
         <Profile></Profile>
         <p className="text-lg font-semibold">{userName}님의 공고 키워드</p>
       </div>
-      <div className="flex items-center justify-center min-w-64 md:w-auto flex-wrap gap-2 mt-6 md:mt-0 md:flex-nowrap">
+      <div className="flex items-center justify-center min-w-60 md:w-auto flex-wrap gap-2 mt-6 md:mt-0 md:flex-nowrap">
         {loading ? (
           <p className="text-gray-500 text-sm">키워드를 불러오는 중...</p>
         ) : keywords.length > 0 ? (

--- a/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentBanner.tsx
+++ b/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentBanner.tsx
@@ -14,12 +14,12 @@ export default function PersonalizedRecruitmentBanner({
   const { data: keywords = [], isLoading: loading } = useKeywords();
 
   return (
-    <div className="p-4 flex flex-col items-center justify-center min-w-64 min-h-36 md:w-full md:min-h-18 md:flex-row md:gap-7 bg-violet-50 rounded-lg mb-3.5">
+    <div className="px-2 py-4 md:p-4 flex flex-col items-center justify-center min-w-64 min-h-36 md:w-full md:min-h-18 md:flex-row md:gap-7 bg-violet-50 rounded-lg mb-3.5">
       <div className="flex items-center gap-2">
         <Profile></Profile>
         <p className="text-lg font-semibold">{userName}님의 공고 키워드</p>
       </div>
-      <div className="flex items-center justify-center w-64 md:w-auto flex-wrap gap-2 mt-6 md:mt-0 md:flex-nowrap">
+      <div className="flex items-center justify-center min-w-64 md:w-auto flex-wrap gap-2 mt-6 md:mt-0 md:flex-nowrap">
         {loading ? (
           <p className="text-gray-500 text-sm">키워드를 불러오는 중...</p>
         ) : keywords.length > 0 ? (

--- a/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentBanner.tsx
+++ b/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentBanner.tsx
@@ -13,7 +13,7 @@ export default function PersonalizedRecruitmentBanner({
   userName = "민수",
   onKeywordClick,
 }: PersonalizedRecruitmentBannerProps) {
-  const { data: keywords = [], isLoading: loading, error } = useKeywords();
+  const { data: keywords = [], isLoading: loading } = useKeywords();
 
   return (
     <div className="p-4 flex flex-col items-center justify-center min-w-64 min-h-36 md:w-full md:min-h-18 md:flex-row md:gap-7 bg-violet-50 rounded-lg mb-3.5">

--- a/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentBanner.tsx
+++ b/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentBanner.tsx
@@ -1,28 +1,39 @@
+"use client";
+
 import { Profile } from "@/components/Icons/Profile";
 import KeywordButton from "./keywordButton";
-
-interface Keyword {
-  id: string;
-  keyword: string;
-}
+import { useState, useEffect } from "react";
+import { fetchKeywords } from "@/app/_api/resume/keyword/keywordApi";
 
 interface PersonalizedRecruitmentBannerProps {
   userName?: string;
-  keywords?: Keyword[];
-  onKeywordClick?: (keywordId: string) => void;
+  onKeywordClick?: (keyword: string) => void;
 }
 
 export default function PersonalizedRecruitmentBanner({
   userName = "민수",
-  keywords = [
-    { id: "1", keyword: "재택" },
-    { id: "2", keyword: "스타트업" },
-    { id: "3", keyword: "대기업" },
-    { id: "4", keyword: "프리랜서" },
-    { id: "5", keyword: "원격근무" },
-  ],
   onKeywordClick,
 }: PersonalizedRecruitmentBannerProps) {
+  const [keywords, setKeywords] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadKeywords = async () => {
+      try {
+        setLoading(true);
+        const fetchedKeywords = await fetchKeywords();
+        setKeywords(fetchedKeywords);
+      } catch (error) {
+        console.error("키워드를 가져오는데 실패했습니다:", error);
+        setKeywords([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadKeywords();
+  }, []);
+
   return (
     <div className="p-4 flex flex-col items-center justify-center min-w-64 min-h-36 md:w-full md:min-h-18 md:flex-row md:gap-7 bg-violet-50 rounded-lg mb-3.5">
       <div className="flex items-center gap-2">
@@ -30,13 +41,19 @@ export default function PersonalizedRecruitmentBanner({
         <p className="text-lg font-semibold">{userName}님의 공고 키워드</p>
       </div>
       <div className="flex items-center justify-center w-64 md:w-auto flex-wrap gap-2 mt-6 md:mt-0 md:flex-nowrap">
-        {keywords.map((keyword) => (
-          <KeywordButton
-            key={keyword.id}
-            keyword={keyword.keyword}
-            onClick={() => onKeywordClick?.(keyword.id)}
-          />
-        ))}
+        {loading ? (
+          <p className="text-gray-500 text-sm">키워드를 불러오는 중...</p>
+        ) : keywords.length > 0 ? (
+          keywords.map((keyword, index) => (
+            <KeywordButton
+              key={`${keyword}-${index}`}
+              keyword={keyword}
+              onClick={() => onKeywordClick?.(keyword)}
+            />
+          ))
+        ) : (
+          <p className="text-gray-500 text-sm">키워드가 없습니다.</p>
+        )}
       </div>
     </div>
   );

--- a/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentCard.tsx
+++ b/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentCard.tsx
@@ -30,7 +30,7 @@ export default function RecruitmentCard({ item }: RecruitmentCardProps) {
   };
 
   return (
-    <div className="border border-gray-200 rounded-lg px-3.5 py-3 w-60 h-34 hover:[box-shadow:0_8px_25px_rgba(0,0,0,0.1)] transition-shadow duration-200 cursor-pointer">
+    <div className="border border-gray-200 rounded-lg px-3.5 py-3 min-w-64 w-full h-34 hover:[box-shadow:0_8px_25px_rgba(0,0,0,0.1)] transition-shadow duration-200 cursor-pointer">
       <div className="flex gap-1 items-cente mb-3.5">
         <button
           onClick={() => setActiveTab("job")}

--- a/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentCard.tsx
+++ b/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentCard.tsx
@@ -30,7 +30,7 @@ export default function RecruitmentCard({ item }: RecruitmentCardProps) {
   };
 
   return (
-    <div className="border border-gray-200 rounded-lg px-3.5 py-3 min-w-64 w-full h-34 hover:[box-shadow:0_8px_25px_rgba(0,0,0,0.1)] transition-shadow duration-200 cursor-pointer">
+    <div className="border border-gray-200 rounded-lg px-3.5 py-3 min-w-60 w-full h-34 hover:[box-shadow:0_8px_25px_rgba(0,0,0,0.1)] transition-shadow duration-200 cursor-pointer">
       <div className="flex gap-1 items-cente mb-3.5">
         <button
           onClick={() => setActiveTab("job")}
@@ -112,7 +112,7 @@ export default function RecruitmentCard({ item }: RecruitmentCardProps) {
           </div>
         </div>
       ) : (
-        <p className=" text-zinc-800 text-sm font-medium">{reason}</p>
+        <p className=" text-zinc-800 text-sm font-medium w-53">{reason}</p>
       )}
     </div>
   );

--- a/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentCard.tsx
+++ b/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentCard.tsx
@@ -11,11 +11,12 @@ interface RecruitmentCardProps {
     company: string;
     title: string;
     bookmarked?: boolean;
+    reason: string;
   };
 }
 
 export default function RecruitmentCard({ item }: RecruitmentCardProps) {
-  const { id, logo, company, title, bookmarked } = item;
+  const { id, logo, company, title, bookmarked, reason } = item;
   const { isBookmarked, mutate, isPending } = useBookmark(id, !!bookmarked);
   const [activeTab, setActiveTab] = useState<"job" | "reason">("job");
 
@@ -94,25 +95,24 @@ export default function RecruitmentCard({ item }: RecruitmentCardProps) {
       </div>
       {activeTab === "job" ? (
         <div className="flex items-start  gap-2.5 mt-1.5 h-full">
-          <div className="w-16 h-16 bg-gray-100 flex items-center justify-center rounded-xs">
+          <div className="w-16 h-16 bg-gray-100 border border-gray-200 flex items-center justify-center rounded-md overflow-hidden">
             <Image
               src={logo}
               alt={`${company} 로고`}
-              className="max-w-full max-h-full "
+              className="w-full h-full object-cover"
               width={60}
               height={60}
             />
           </div>
           <div className="h-16 flex flex-col justify-between">
-            <p className="font-semibold text-base">{title}</p>
+            <p className="font-semibold text-base w-35 h-11 line-clamp-2">
+              {title}
+            </p>
             <p className="text-neutral-400 font-medium text-xs">{company}</p>
           </div>
         </div>
       ) : (
-        <p className=" text-zinc-800 text-sm font-medium">
-          평소 재택근무를 좋아한다는 키워드와 가우디오랩의 근무환경과 일치하여
-          추천하였어요.
-        </p>
+        <p className=" text-zinc-800 text-sm font-medium">{reason}</p>
       )}
     </div>
   );

--- a/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentList.tsx
+++ b/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentList.tsx
@@ -112,7 +112,13 @@ export default function PersonalizedRecruitmentList({
     <div
       className={`w-full ${className} items-center justify-center flex flex-col`}
     >
-      <PersonalizedRecruitmentBanner></PersonalizedRecruitmentBanner>
+      <PersonalizedRecruitmentBanner
+        userName="민수"
+        onKeywordClick={(keyword) => {
+          console.log("선택된 키워드:", keyword);
+          // 키워드 클릭 시 처리 로직 추가 가능
+        }}
+      />
       {/* 그리드 레이아웃 */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6 ">
         {currentItems.map((item, index) => (

--- a/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentList.tsx
+++ b/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentList.tsx
@@ -41,6 +41,7 @@ interface RecruitmentItem {
   company: string;
   title: string;
   bookmarked?: boolean;
+  reason: string;
 }
 
 interface PersonalizedRecruitmentListProps {
@@ -69,7 +70,8 @@ export default function PersonalizedRecruitmentList({
   }, []);
 
   // 반응형 itemsPerPage 설정
-  const currentItemsPerPage = itemsPerPage !== undefined ? itemsPerPage : 9;
+  const currentItemsPerPage =
+    itemsPerPage !== undefined ? itemsPerPage : isMobile ? 3 : 9;
 
   // 총 페이지 수 계산
   const totalPages = Math.ceil(items.length / currentItemsPerPage);
@@ -77,10 +79,7 @@ export default function PersonalizedRecruitmentList({
   // 현재 페이지에 해당하는 아이템들 계산
   const startIndex = (currentPage - 1) * currentItemsPerPage;
   const endIndex = startIndex + currentItemsPerPage;
-  const allCurrentItems = items.slice(startIndex, endIndex);
-
-  // 모바일에서는 3개만 표시, PC에서는 9개 표시
-  const currentItems = isMobile ? allCurrentItems.slice(0, 3) : allCurrentItems;
+  const currentItems = items.slice(startIndex, endIndex);
 
   // 페이지 변경 핸들러
   const handlePageChange = (page: number) => {
@@ -112,13 +111,8 @@ export default function PersonalizedRecruitmentList({
     <div
       className={`w-full ${className} items-center justify-center flex flex-col`}
     >
-      <PersonalizedRecruitmentBanner
-        userName="민수"
-        onKeywordClick={(keyword) => {
-          console.log("선택된 키워드:", keyword);
-          // 키워드 클릭 시 처리 로직 추가 가능
-        }}
-      />
+      <PersonalizedRecruitmentBanner userName="민수" />
+
       {/* 그리드 레이아웃 */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6 ">
         {currentItems.map((item, index) => (

--- a/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentList.tsx
+++ b/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentList.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import PersonalizedRecruitmentCard from "./PersonalizedRecruitmentCard";
+import PersonalizedRecruitmentBanner from "./PersonalizedRecruitmentBanner";
 
 // 페이지네이션 아이콘 컴포넌트
 const ChevronLeftIcon = ({ isDisabled }: { isDisabled: boolean }) => (
@@ -130,6 +131,7 @@ export default function PersonalizedRecruitmentList({
     <div
       className={`w-full ${className} items-center justify-center flex flex-col`}
     >
+      <PersonalizedRecruitmentBanner userName="민수" />
       {/* 그리드 레이아웃 */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6 ">
         {currentItems.map((item, index) => (

--- a/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentList.tsx
+++ b/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentList.tsx
@@ -115,8 +115,11 @@ export default function PersonalizedRecruitmentList({
       <PersonalizedRecruitmentBanner></PersonalizedRecruitmentBanner>
       {/* 그리드 레이아웃 */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6 ">
-        {currentItems.map((item) => (
-          <PersonalizedRecruitmentCard key={item.id} item={item} />
+        {currentItems.map((item, index) => (
+          <PersonalizedRecruitmentCard
+            key={`${item.id}-${item.company}-${item.title}-${index}`}
+            item={item}
+          />
         ))}
       </div>
 

--- a/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentList.tsx
+++ b/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentList.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from "react";
 import PersonalizedRecruitmentCard from "./PersonalizedRecruitmentCard";
-import PersonalizedRecruitmentBanner from "./PersonalizedRecruitmentBanner";
 
 // 페이지네이션 아이콘 컴포넌트
 const ChevronLeftIcon = ({ isDisabled }: { isDisabled: boolean }) => (
@@ -111,8 +110,6 @@ export default function PersonalizedRecruitmentList({
     <div
       className={`w-full ${className} items-center justify-center flex flex-col`}
     >
-      <PersonalizedRecruitmentBanner userName="민수" />
-
       {/* 그리드 레이아웃 */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6 ">
         {currentItems.map((item, index) => (

--- a/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentList.tsx
+++ b/src/app/(pages)/personal/_components/recruitment/PersonalizedRecruitmentList.tsx
@@ -66,7 +66,7 @@ export default function PersonalizedRecruitmentList({
 
   useEffect(() => {
     const checkIsMobile = () => {
-      setIsMobile(window.innerWidth < 768);
+      setIsMobile(window.innerWidth < 1416);
     };
 
     checkIsMobile();

--- a/src/app/(pages)/personal/_components/recruitment/stories/PersonalizedRecruitmentBanner.stories.tsx
+++ b/src/app/(pages)/personal/_components/recruitment/stories/PersonalizedRecruitmentBanner.stories.tsx
@@ -13,10 +13,6 @@ const meta: Meta<typeof PersonalizedRecruitmentBanner> = {
       control: "text",
       description: "사용자 이름",
     },
-    onKeywordClick: {
-      action: "keywordClicked",
-      description: "키워드 클릭 이벤트 핸들러",
-    },
   },
 };
 
@@ -38,8 +34,5 @@ export const DifferentUser: Story = {
 export const Interactive: Story = {
   args: {
     userName: "테스트",
-    onKeywordClick: (keyword) => {
-      console.log(`키워드 ${keyword}가 클릭되었습니다.`);
-    },
   },
 };

--- a/src/app/(pages)/personal/_components/recruitment/stories/PersonalizedRecruitmentBanner.stories.tsx
+++ b/src/app/(pages)/personal/_components/recruitment/stories/PersonalizedRecruitmentBanner.stories.tsx
@@ -13,10 +13,6 @@ const meta: Meta<typeof PersonalizedRecruitmentBanner> = {
       control: "text",
       description: "사용자 이름",
     },
-    keywords: {
-      control: "object",
-      description: "키워드 배열",
-    },
     onKeywordClick: {
       action: "keywordClicked",
       description: "키워드 클릭 이벤트 핸들러",
@@ -30,56 +26,20 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     userName: "민수",
-    keywords: [
-      { id: "1", keyword: "재택" },
-      { id: "2", keyword: "스타트업" },
-      { id: "3", keyword: "대기업" },
-      { id: "4", keyword: "프리랜서" },
-      { id: "5", keyword: "원격근무" },
-    ],
   },
 };
 
 export const DifferentUser: Story = {
   args: {
     userName: "지영",
-    keywords: [
-      { id: "1", keyword: "대기업" },
-      { id: "2", keyword: "정규직" },
-      { id: "3", keyword: "복지" },
-      { id: "4", keyword: "성장" },
-    ],
-  },
-};
-
-export const ManyKeywords: Story = {
-  args: {
-    userName: "현우",
-    keywords: [
-      { id: "1", keyword: "재택" },
-      { id: "2", keyword: "스타트업" },
-      { id: "3", keyword: "대기업" },
-      { id: "4", keyword: "프리랜서" },
-      { id: "5", keyword: "원격근무" },
-      { id: "6", keyword: "정규직" },
-      { id: "7", keyword: "복지" },
-      { id: "8", keyword: "성장" },
-    ],
   },
 };
 
 export const Interactive: Story = {
   args: {
     userName: "테스트",
-    keywords: [
-      { id: "1", keyword: "재택" },
-      { id: "2", keyword: "스타트업" },
-      { id: "3", keyword: "대기업" },
-      { id: "4", keyword: "프리랜서" },
-      { id: "5", keyword: "원격근무" },
-    ],
-    onKeywordClick: (keywordId) => {
-      console.log(`키워드 ${keywordId}가 클릭되었습니다.`);
+    onKeywordClick: (keyword) => {
+      console.log(`키워드 ${keyword}가 클릭되었습니다.`);
     },
   },
 };

--- a/src/app/(pages)/personal/_components/recruitment/stories/PersonalizedRecruitmentCard.stories.tsx
+++ b/src/app/(pages)/personal/_components/recruitment/stories/PersonalizedRecruitmentCard.stories.tsx
@@ -27,6 +27,7 @@ export const Default: Story = {
       company: "테크스타트업",
       title: "프론트엔드 개발자",
       bookmarked: false,
+      reason: "프론트엔드 개발 경험과 React 기술 스택이 일치합니다.",
     },
   },
 };

--- a/src/app/(pages)/personal/_components/recruitment/stories/PersonalizedRecruitmentList.stories.tsx
+++ b/src/app/(pages)/personal/_components/recruitment/stories/PersonalizedRecruitmentList.stories.tsx
@@ -78,6 +78,9 @@ const generateSampleData = (count: number) => {
     company: companies[index % companies.length],
     title: positions[index % positions.length],
     bookmarked: Math.random() > 0.5,
+    reason: `${
+      positions[index % positions.length]
+    } 경험과 기술 스택이 요구사항과 일치합니다.`,
   }));
 };
 

--- a/src/app/(pages)/personal/_components/stories/PersonalBanner.stories.tsx
+++ b/src/app/(pages)/personal/_components/stories/PersonalBanner.stories.tsx
@@ -9,9 +9,9 @@ const meta: Meta<typeof PersonalBanner> = {
   },
   tags: ["autodocs"],
   argTypes: {
-    files: {
-      control: "object",
-      description: "파일 목록 (파일이 있으면 배너가 숨겨짐)",
+    hasFiles: {
+      control: "boolean",
+      description: "파일 존재 여부 (파일이 있으면 배너가 숨겨짐)",
     },
   },
 };
@@ -21,41 +21,12 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    files: [],
+    hasFiles: false,
   },
 };
 
 export const WithFiles: Story = {
   args: {
-    files: [
-      {
-        id: "1",
-        name: "resume.pdf",
-        uploadedAt: "2024-01-15",
-      },
-    ],
-  },
-};
-
-export const EmptyFiles: Story = {
-  args: {
-    files: [],
-  },
-};
-
-export const MultipleFiles: Story = {
-  args: {
-    files: [
-      {
-        id: "1",
-        name: "resume.pdf",
-        uploadedAt: "2024-01-15",
-      },
-      {
-        id: "2",
-        name: "cover_letter.doc",
-        uploadedAt: "2024-01-16",
-      },
-    ],
+    hasFiles: true,
   },
 };

--- a/src/app/(pages)/personal/_components/uploadArea.tsx
+++ b/src/app/(pages)/personal/_components/uploadArea.tsx
@@ -108,7 +108,9 @@ export default function UploadArea({ onFilesChange }: UploadAreaProps) {
       />
       <FileExploreModal
         open={showExploreModal}
-        onClose={() => setShowExploreModal(false)}
+        onClose={() => {
+          setShowExploreModal(false);
+        }}
         progress={progress}
       />
     </div>

--- a/src/app/(pages)/personal/_components/uploadArea.tsx
+++ b/src/app/(pages)/personal/_components/uploadArea.tsx
@@ -6,55 +6,27 @@ import FileList from "./file/fileList";
 import FileUploadModal from "./file/fileUploadModal";
 import FileExploreModal from "./file/fileExploreModal";
 
-type FileRow = {
-  id: string;
-  name: string;
-  uploadedAt: string;
-};
-
 type UploadAreaProps = {
-  onFilesChange?: (files: FileRow[]) => void;
-  initialFiles?: FileRow[];
+  onFilesChange?: (hasFiles: boolean) => void;
 };
 
-export const mockFiles: FileRow[] = [
-  {
-    id: "1",
-    name: "이력서_김민수.pdf",
-    uploadedAt: "2025-09-10",
-  },
-  {
-    id: "2",
-    name: "자기소개서_김민수.docx",
-    uploadedAt: "2025-09-11",
-  },
-  {
-    id: "3",
-    name: "포트폴리오_프로젝트.pdf",
-    uploadedAt: "2025-09-12",
-  },
-];
-
-export default function UploadArea({
-  onFilesChange,
-  initialFiles = [],
-}: UploadAreaProps) {
+export default function UploadArea({ onFilesChange }: UploadAreaProps) {
   const [showTooltip, setShowTooltip] = useState(true);
   const [openModal, setOpenModal] = useState(false);
   const [showExploreModal, setShowExploreModal] = useState(false);
   const [progress, setProgress] = useState(0);
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
+
   const handleUpload = () => {
     setOpenModal(true);
-  };
-
-  const handleDelete = () => {
-    console.log(1);
   };
 
   const handleUploadComplete = () => {
     setOpenModal(false);
     setShowExploreModal(true);
     setProgress(0);
+    // 파일 목록 새로고침 트리거
+    setRefreshTrigger((prev) => prev + 1);
 
     // 진행률 시뮬레이션 (공고 찾기 - 부드럽게)
     const interval = setInterval(() => {
@@ -120,7 +92,7 @@ export default function UploadArea({
         </div>
       </div>
 
-      <FileList onDelete={handleDelete} />
+      <FileList onFilesChange={onFilesChange} refreshTrigger={refreshTrigger} />
       <button
         type="button"
         onClick={handleUpload}

--- a/src/app/(pages)/personal/_components/uploadArea.tsx
+++ b/src/app/(pages)/personal/_components/uploadArea.tsx
@@ -15,8 +15,6 @@ export default function UploadArea({ onFilesChange }: UploadAreaProps) {
   const [openModal, setOpenModal] = useState(false);
   const [showExploreModal, setShowExploreModal] = useState(false);
   const [progress, setProgress] = useState(0);
-  const [refreshTrigger, setRefreshTrigger] = useState(0);
-
   const handleUpload = () => {
     setOpenModal(true);
   };
@@ -25,8 +23,6 @@ export default function UploadArea({ onFilesChange }: UploadAreaProps) {
     setOpenModal(false);
     setShowExploreModal(true);
     setProgress(0);
-    // 파일 목록 새로고침 트리거
-    setRefreshTrigger((prev) => prev + 1);
 
     // 진행률 시뮬레이션 (공고 찾기 - 부드럽게)
     const interval = setInterval(() => {
@@ -92,7 +88,7 @@ export default function UploadArea({ onFilesChange }: UploadAreaProps) {
         </div>
       </div>
 
-      <FileList onFilesChange={onFilesChange} refreshTrigger={refreshTrigger} />
+      <FileList onFilesChange={onFilesChange} />
       <button
         type="button"
         onClick={handleUpload}

--- a/src/app/(pages)/personal/_components/uploadArea.tsx
+++ b/src/app/(pages)/personal/_components/uploadArea.tsx
@@ -8,9 +8,13 @@ import FileExploreModal from "./file/fileExploreModal";
 
 type UploadAreaProps = {
   onFilesChange?: (hasFiles: boolean) => void;
+  onAnalysisModalChange?: (isOpen: boolean) => void;
 };
 
-export default function UploadArea({ onFilesChange }: UploadAreaProps) {
+export default function UploadArea({
+  onFilesChange,
+  onAnalysisModalChange,
+}: UploadAreaProps) {
   const [showTooltip, setShowTooltip] = useState(true);
   const [openModal, setOpenModal] = useState(false);
   const [showExploreModal, setShowExploreModal] = useState(false);
@@ -23,6 +27,7 @@ export default function UploadArea({ onFilesChange }: UploadAreaProps) {
     setOpenModal(false);
     setShowExploreModal(true);
     setProgress(0);
+    onAnalysisModalChange?.(true);
 
     // 진행률 시뮬레이션 (공고 찾기 - 부드럽게)
     const interval = setInterval(() => {
@@ -31,6 +36,7 @@ export default function UploadArea({ onFilesChange }: UploadAreaProps) {
           clearInterval(interval);
           setTimeout(() => {
             setShowExploreModal(false);
+            onAnalysisModalChange?.(false);
           }, 2000);
           return 100;
         }
@@ -88,7 +94,7 @@ export default function UploadArea({ onFilesChange }: UploadAreaProps) {
         </div>
       </div>
 
-      <FileList onFilesChange={onFilesChange} />
+      {!showExploreModal && <FileList onFilesChange={onFilesChange} />}
       <button
         type="button"
         onClick={handleUpload}

--- a/src/app/(pages)/today/_components/TodayClient.tsx
+++ b/src/app/(pages)/today/_components/TodayClient.tsx
@@ -6,8 +6,6 @@ import FilterBar from "../../[category]/_components/Filter/FilterBar";
 import FilterModal from "../../[category]/_components/Filter/FilterModal";
 import {
   FilterDialogProvider,
-  DEFAULT,
-  type FilterState,
   useFilterDialog,
 } from "../../[category]/_hooks/useFilterDialog";
 import { mapFiltersToParams } from "@/app/_utils/mapFiltersToParams";

--- a/src/app/_api/recruitment/recommend/recommend.ts
+++ b/src/app/_api/recruitment/recommend/recommend.ts
@@ -1,0 +1,30 @@
+import type { RecommendResponse } from "@/app/_types/jobs";
+
+function getAccessToken(): string | null {
+  try {
+    return localStorage.getItem("zh_access_token");
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchRecommendedRecruitments(): Promise<RecommendResponse> {
+  const token = getAccessToken();
+  const url = `/api/users/recommend`;
+
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+  }
+
+  return res.json();
+}

--- a/src/app/_api/recruitment/recommend/recommend.ts
+++ b/src/app/_api/recruitment/recommend/recommend.ts
@@ -8,9 +8,12 @@ function getAccessToken(): string | null {
   }
 }
 
-export async function fetchRecommendedRecruitments(): Promise<RecommendResponse> {
+export async function fetchRecommendedRecruitments(
+  page: number = 0,
+  size: number = 9
+): Promise<RecommendResponse> {
   const token = getAccessToken();
-  const url = `/api/users/recommend`;
+  const url = `/api/users/recommend?page=${page}&size=${size}`;
 
   const res = await fetch(url, {
     method: "GET",

--- a/src/app/_api/recruitment/recommend/recommend.ts
+++ b/src/app/_api/recruitment/recommend/recommend.ts
@@ -31,3 +31,26 @@ export async function fetchRecommendedRecruitments(
 
   return res.json();
 }
+
+// 모든 추천 공고를 한 번에 가져오는 함수
+export async function fetchAllRecommendedRecruitments(): Promise<RecommendResponse> {
+  const token = getAccessToken();
+  // 큰 사이즈로 설정하여 모든 데이터를 한 번에 가져옴
+  const url = `/api/users/recommend?page=0&size=100`;
+
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+  }
+
+  return res.json();
+}

--- a/src/app/_api/recruitment/recommend/useRecommend.ts
+++ b/src/app/_api/recruitment/recommend/useRecommend.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import {
+  fetchAllRecommendedRecruitments,
+  fetchRecommendedRecruitments,
+} from "./recommend";
+import type { RecommendResponse } from "@/app/_types/jobs";
+
+export function useRecommendedRecruitments(
+  page: number = 0,
+  size: number = 9,
+  options?: { enabled?: boolean }
+) {
+  return useQuery<RecommendResponse>({
+    queryKey: ["recommendations", "paginated", { page, size }],
+    queryFn: () => fetchRecommendedRecruitments(page, size),
+    enabled: options?.enabled ?? true,
+    staleTime: 5 * 60 * 1000, // 5분
+    gcTime: 10 * 60 * 1000, // 10분
+  });
+}
+
+export function useAllRecommendedRecruitments(options?: { enabled?: boolean }) {
+  return useQuery<RecommendResponse>({
+    queryKey: ["recommendations", "all"],
+    queryFn: () => fetchAllRecommendedRecruitments(),
+    enabled: options?.enabled ?? true,
+    staleTime: 5 * 60 * 1000, // 5분
+    gcTime: 10 * 60 * 1000, // 10분
+  });
+}

--- a/src/app/_api/resume/hooks/useKeywords.ts
+++ b/src/app/_api/resume/hooks/useKeywords.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { fetchKeywords } from "../keyword/keywordApi";
+
+// Query Keys
+export const keywordKeys = {
+  all: ["keywords"] as const,
+  lists: () => [...keywordKeys.all, "list"] as const,
+};
+
+// 키워드 목록 조회
+export function useKeywords() {
+  return useQuery({
+    queryKey: keywordKeys.lists(),
+    queryFn: fetchKeywords,
+    staleTime: 10 * 60 * 1000, // 10분 (키워드는 자주 변경되지 않음)
+    gcTime: 30 * 60 * 1000, // 30분
+  });
+}

--- a/src/app/_api/resume/hooks/useResumes.ts
+++ b/src/app/_api/resume/hooks/useResumes.ts
@@ -1,7 +1,12 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { fetchResumes, uploadResume, deleteResume } from "../resumeApi";
+import {
+  fetchResumes,
+  uploadResume,
+  deleteResume,
+  downloadResume,
+} from "../resumeApi";
 
 // Query Keys
 export const resumeKeys = {
@@ -48,6 +53,31 @@ export function useDeleteResume() {
     },
     onError: (error) => {
       console.error("이력서 삭제 실패:", error);
+    },
+  });
+}
+
+// 이력서 다운로드
+export function useDownloadResume() {
+  return useMutation({
+    mutationFn: async (resumeId: string) => {
+      const blob = await downloadResume(resumeId);
+      return blob;
+    },
+    onSuccess: (blob, resumeId) => {
+      // 다운로드 성공 시 파일 다운로드 실행
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `resume-${resumeId}.pdf`; // 파일명 설정
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+    },
+    onError: (error) => {
+      console.error("이력서 다운로드 실패:", error);
+      alert("파일 다운로드에 실패했습니다.");
     },
   });
 }

--- a/src/app/_api/resume/hooks/useResumes.ts
+++ b/src/app/_api/resume/hooks/useResumes.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { fetchResumes, uploadResume, deleteResume } from "../resumeApi";
+
+// Query Keys
+export const resumeKeys = {
+  all: ["resumes"] as const,
+  lists: () => [...resumeKeys.all, "list"] as const,
+  list: (filters: string) => [...resumeKeys.lists(), { filters }] as const,
+};
+
+// 이력서 목록 조회
+export function useResumes() {
+  return useQuery({
+    queryKey: resumeKeys.lists(),
+    queryFn: fetchResumes,
+    staleTime: 5 * 60 * 1000, // 5분
+    gcTime: 10 * 60 * 1000, // 10분
+  });
+}
+
+// 이력서 업로드
+export function useUploadResume() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: uploadResume,
+    onSuccess: () => {
+      // 업로드 성공 시 목록 새로고침
+      queryClient.invalidateQueries({ queryKey: resumeKeys.lists() });
+    },
+    onError: (error) => {
+      console.error("이력서 업로드 실패:", error);
+    },
+  });
+}
+
+// 이력서 삭제
+export function useDeleteResume() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteResume,
+    onSuccess: () => {
+      // 삭제 성공 시 목록 새로고침
+      queryClient.invalidateQueries({ queryKey: resumeKeys.lists() });
+    },
+    onError: (error) => {
+      console.error("이력서 삭제 실패:", error);
+    },
+  });
+}

--- a/src/app/_api/resume/keyword/keywordApi.ts
+++ b/src/app/_api/resume/keyword/keywordApi.ts
@@ -1,0 +1,38 @@
+const API_BASE = "/api/resumes/keywords";
+
+function getAccessToken(): string | null {
+  try {
+    if (typeof window === "undefined") return null;
+    return localStorage.getItem("zh_access_token");
+  } catch {
+    return null;
+  }
+}
+
+export interface KeywordResponse {
+  success: boolean;
+  code: string | null;
+  message: string | null;
+  data: {
+    keywords: string[];
+  };
+}
+
+export async function fetchKeywords(): Promise<string[]> {
+  const token = getAccessToken();
+  const url = API_BASE;
+
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+  const json: KeywordResponse = await res.json();
+  return json?.data?.keywords ?? [];
+}

--- a/src/app/_api/resume/resumeApi.ts
+++ b/src/app/_api/resume/resumeApi.ts
@@ -59,7 +59,7 @@ export async function uploadResume(file: File): Promise<ResumeUploadResponse> {
   const url = API_BASE;
 
   const formData = new FormData();
-  formData.append("file", file);
+  formData.append("resumeFile", file);
 
   const res = await fetch(url, {
     method: "POST",

--- a/src/app/_api/resume/resumeApi.ts
+++ b/src/app/_api/resume/resumeApi.ts
@@ -1,0 +1,91 @@
+const API_BASE = "/api/resumes";
+
+// 타입 정의
+export interface ResumeUploadResponse {
+  success: boolean;
+  code: string | null;
+  message: string | null;
+  data: {
+    fileName: string;
+    fileUrl: string;
+    size: number;
+    uploadDate: string;
+  };
+}
+
+export interface Resume {
+  id: string;
+  fileName: string;
+  fileUrl: string;
+  size: number;
+  uploadDate: string;
+}
+
+export interface ResumeListResponse {
+  resumes: Resume[];
+}
+
+// 토큰 가져오기
+function getAccessToken(): string | null {
+  try {
+    if (typeof window === "undefined") return null;
+    return localStorage.getItem("zh_access_token");
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchResumes(): Promise<ResumeListResponse> {
+  const token = getAccessToken();
+  const url = API_BASE;
+
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+  const json = await res.json();
+  return { resumes: json?.data?.resumes ?? [] };
+}
+
+export async function uploadResume(file: File): Promise<ResumeUploadResponse> {
+  const token = getAccessToken();
+  const url = API_BASE;
+
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: formData,
+    cache: "no-store",
+  });
+
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+  const json = await res.json();
+  return json;
+}
+
+export async function deleteResume(resumeId: string): Promise<void> {
+  const token = getAccessToken();
+  const res = await fetch(`${API_BASE}/${resumeId}`, {
+    method: "DELETE",
+    headers: {
+      Accept: "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+}

--- a/src/app/_api/resume/resumeApi.ts
+++ b/src/app/_api/resume/resumeApi.ts
@@ -6,6 +6,7 @@ export interface ResumeUploadResponse {
   code: string | null;
   message: string | null;
   data: {
+    id: string;
     fileName: string;
     fileUrl: string;
     size: number;
@@ -51,7 +52,7 @@ export async function fetchResumes(): Promise<ResumeListResponse> {
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
 
   const json = await res.json();
-  return { resumes: json?.data?.resumes ?? [] };
+  return { resumes: json?.data ?? [] };
 }
 
 export async function uploadResume(file: File): Promise<ResumeUploadResponse> {

--- a/src/app/_api/resume/resumeApi.ts
+++ b/src/app/_api/resume/resumeApi.ts
@@ -90,3 +90,18 @@ export async function deleteResume(resumeId: string): Promise<void> {
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
 }
+
+export async function downloadResume(resumeId: string): Promise<Blob> {
+  const token = getAccessToken();
+  const res = await fetch(`${API_BASE}/${resumeId}/download`, {
+    method: "GET",
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+  return res.blob();
+}

--- a/src/app/_types/jobs.ts
+++ b/src/app/_types/jobs.ts
@@ -15,3 +15,31 @@ export interface Job {
   bookmarked?: boolean;
   jobGroup?: string;
 }
+
+// 추천 채용공고 API 응답 타입
+export interface RecommendedRecruitment {
+  id: string;
+  title: string;
+  description: string;
+  recruitmentUrl: string;
+  imageUrl: string;
+  locations: string[];
+  minExperience: number;
+  maxExperience: number;
+  educations: string[];
+  employmentTypes: string[];
+  jobs: string[];
+  jobCategories: string[];
+  companyName: string;
+  companyDescription: string;
+  companyImageUrl: string;
+  isBookmarked: boolean;
+  reason: string;
+}
+
+export interface RecommendResponse {
+  success: boolean;
+  code: string | null;
+  message: string | null;
+  data: RecommendedRecruitment[];
+}

--- a/src/app/_types/jobs.ts
+++ b/src/app/_types/jobs.ts
@@ -32,7 +32,7 @@ export interface RecommendedRecruitment {
   jobCategories: string[];
   companyName: string;
   companyDescription: string;
-  companyImageUrl: string;
+  companyImageUrl: string | null;
   isBookmarked: boolean;
   reason: string;
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,14 +2,25 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import Profile from "./Icons/Profile";
+
+// 토큰 가져오기 함수
+function getAccessToken(): string | null {
+  try {
+    if (typeof window === "undefined") return null;
+    return localStorage.getItem("zh_access_token");
+  } catch {
+    return null;
+  }
+}
 
 export default function Header() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const pathname = usePathname();
+  const router = useRouter();
 
   const toggleSidebar = () => {
     setIsSidebarOpen(!isSidebarOpen);
@@ -17,6 +28,19 @@ export default function Header() {
 
   const closeSidebar = () => {
     setIsSidebarOpen(false);
+  };
+
+  const handlePersonalClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const token = getAccessToken();
+
+    if (token) {
+      // 로그인된 경우 맞춤공고 페이지로 이동
+      router.push("/personal");
+    } else {
+      // 로그인되지 않은 경우 로그인 페이지로 이동
+      router.push("/join");
+    }
   };
 
   useEffect(() => {
@@ -83,9 +107,12 @@ export default function Header() {
                 className="relative hidden hbp:block"
                 style={{ display: "hidden" }}
               >
-                <Link href="/personal" className="pointer-events-auto relative">
+                <button
+                  onClick={handlePersonalClick}
+                  className="pointer-events-auto relative cursor-pointer"
+                >
                   <div className="text-[#353535] ds-web-navi">맞춤 공고</div>
-                </Link>
+                </button>
                 {pathname === "/personal" && (
                   <div className="absolute w-full border border-primary/80"></div>
                 )}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #83 

## 📝작업 내용

<img width="1970" height="1271" alt="image" src="https://github.com/user-attachments/assets/34fb563b-d839-4998-a026-bf5bc42b330b" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 이력서 목록/업로드/삭제/다운로드 API 연동
  - 맞춤 공고 API 연동 및 페이지네이션 지원
  - 키워드 배너가 키워드 자동 로딩
  - 로그인 여부에 따른 맞춤 공고 진입 경로 분기

- UX/Behavior
  - 파일 목록 자동 갱신, 삭제/다운로드 진행 상태 표시
  - 업로드 완료 시 제출 진행 표시 및 분석 모달 상태 연동
  - 맞춤 공고 영역에 로딩/에러 상태, 모바일 대응 페이지 크기
  - 카드에 추천 사유(reason) 노출

- Refactor
  - 파일 배열 대신 hasFiles 불리언 등 단순화된 props로 변경
  - FileList가 내부적으로 데이터 조회하도록 전환
  - 리스트 컴포넌트가 내부/외부 페이지네이션 모두 지원

- Documentation
  - Storybook 스토리를 신규 props/데이터 구조로 업데이트하고 불필요한 스토리 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->